### PR TITLE
Added 'Request Days Off' functionality to admin_home and admin navbar section.

### DIFF
--- a/src/hr_management/user/templates/administrator/admin_home.html
+++ b/src/hr_management/user/templates/administrator/admin_home.html
@@ -15,7 +15,7 @@
                 <h4>Requests</h4>
                 <p>View and manage employee requests.</p>
                 <a href="{% url 'manage_req' %}"><button class="btn btn-info" type="button">Manage Requests</button></a>
-                <a href="{% url 'submit_req' %}"><button class="btn btn-info" type="button">Requests Days Off</button></a>
+                <a href="{% url 'submit_req' %}"><button class="btn btn-info" type="button">Request Days Off</button></a>
             </div>
             <div class="division-4-item">
                 <h4>Create Publications</h4>

--- a/src/hr_management/user/templates/administrator/admin_home.html
+++ b/src/hr_management/user/templates/administrator/admin_home.html
@@ -15,7 +15,7 @@
                 <h4>Requests</h4>
                 <p>View and manage employee requests.</p>
                 <a href="{% url 'manage_req' %}"><button class="btn btn-info" type="button">Manage Requests</button></a>
-                <a href="{% url 'submit_req' %}"><button class="btn btn-info" type="button">Request Days Off</button></a>
+                <a href="{% url 'submit_req' %}"><button class="btn btn-warning" type="button">Request Days Off</button></a>
             </div>
             <div class="division-4-item">
                 <h4>Create Publications</h4>

--- a/src/hr_management/user/templates/administrator/admin_home.html
+++ b/src/hr_management/user/templates/administrator/admin_home.html
@@ -12,9 +12,10 @@
                 <a href="{% url 'manage_employees' %}"><button class="btn btn-info" type="button">Manage Employees</button></a>
             </div>
             <div class="division-4-item">
-                <h4>Manage Requests</h4>
+                <h4>Requests</h4>
                 <p>View and manage employee requests.</p>
                 <a href="{% url 'manage_req' %}"><button class="btn btn-info" type="button">Manage Requests</button></a>
+                <a href="{% url 'submit_req' %}"><button class="btn btn-info" type="button">Requests Days Off</button></a>
             </div>
             <div class="division-4-item">
                 <h4>Create Publications</h4>

--- a/src/hr_management/user/templates/navbar.html
+++ b/src/hr_management/user/templates/navbar.html
@@ -32,6 +32,9 @@
             <a class="nav-link" href="{% url 'manage_req' %}">Manage Requests</a>
           </p> 
           <p class="nav-item">
+            <a class="nav-link" href="{% url 'submit_req' %}">Request Days Off</a>
+          </p> 
+          <p class="nav-item">
             <a class="nav-link" href="{% url 'create_publication' %}">Publications</a>
           </p>      
           <p class="nav-item">


### PR DESCRIPTION
Now admin can access from its home page the same submit_request/ page that the employee uses for requesting paid time off. After this change, admin can request day off for itself, but will also have to approve its own requests.